### PR TITLE
feat: add cover image to page matadata

### DIFF
--- a/templates/partials/head.html
+++ b/templates/partials/head.html
@@ -11,6 +11,11 @@
   <!-- Meta -->
   <meta name="theme-color" />
 
+  <!-- page cover preview -->
+  {% if page.extra.cover_image %}
+  <meta property="og:image" content="{{ get_url(path=page.extra.cover_image) }}" />
+  {% endif %}
+
   <!-- Author -->
   {% if page %}
   <meta name="description" content="{{ page.summary | default(value=page.title) | safe }}" />


### PR DESCRIPTION
This change cause to display the page's cover image in web page preview (in social media such as telegram, mastodon, discord, etc.)

Example :
![image](https://github.com/st1020/kita/assets/81515807/d26d52fe-8d9d-43c4-a524-25ed99ad50b5)


