### PR TITLE
Add optional cover image captions

### DIFF
--- a/content/markdown-syntax.md
+++ b/content/markdown-syntax.md
@@ -5,7 +5,8 @@ description = "Sample article showcasing basic Markdown syntax and formatting fo
 [taxonomies]
 tags = ["markdown", "css", "html"]
 [extra]
-cover_image = "images/markdown-syntax.png"
+cover.image = "images/markdown-syntax.png"
+cover.caption = "A Markdown logo"
 +++
 
 This article offers a sample of basic Markdown syntax that can be used in Zola content files, also it shows whether basic HTML elements are decorated with CSS in a Kita theme.

--- a/content/markdown-syntax.md
+++ b/content/markdown-syntax.md
@@ -6,7 +6,7 @@ description = "Sample article showcasing basic Markdown syntax and formatting fo
 tags = ["markdown", "css", "html"]
 [extra]
 cover.image = "images/markdown-syntax.png"
-cover.caption = "A Markdown logo"
+cover.alt = "A Markdown logo"
 +++
 
 This article offers a sample of basic Markdown syntax that can be used in Zola content files, also it shows whether basic HTML elements are decorated with CSS in a Kita theme.

--- a/templates/page.html
+++ b/templates/page.html
@@ -6,12 +6,13 @@
     {% include "partials/page_info.html" %}
   </header>
 
-  {% if page.extra.cover_image %}<!---->
+  {% if page.extra.cover.image %}<!---->
   <figure class="mb-12 mt-0">
     <img
       class="h-auto w-full rounded-lg"
-      src="{{ get_url(path=page.extra.cover_image) }}"
-      alt="cover"
+      src="{{ get_url(path=page.extra.cover.image) }}"
+      alt="{{ page.extra.cover.caption | default(value='cover') }}"
+      title="{{ page.extra.cover.caption | default(value='cover') }}"
     />
   </figure>
   {% endif %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -11,8 +11,7 @@
     <img
       class="h-auto w-full rounded-lg"
       src="{{ get_url(path=page.extra.cover.image) }}"
-      alt="{{ page.extra.cover.caption | default(value='cover') }}"
-      title="{{ page.extra.cover.caption | default(value='cover') }}"
+      alt="{{ page.extra.cover.alt | default(value='cover') }}"
     />
   </figure>
   {% endif %}

--- a/templates/partials/head.html
+++ b/templates/partials/head.html
@@ -36,9 +36,9 @@
   <meta property="og:site_name" content="{{ config.title }}" />
   <meta property="og:description" content="{{ description }}" />
   <meta property="og:url" content="{{ page.permalink }}" />
-  {% if page.extra.cover_image %}
+  {% if page.extra.cover.image %}
   <!---->
-  {% set image = page.extra.cover_image %}
+  {% set image = page.extra.cover.image %}
   <!---->
   {% elif config.extra.social_image %}
   <!---->

--- a/templates/partials/page_list.html
+++ b/templates/partials/page_list.html
@@ -12,12 +12,13 @@
 <section
   class="block-bg relative mb-4 rounded-lg p-4 first-of-type:mt-0 last-of-type:mb-0 active:scale-95 lg:mb-6 lg:p-6"
 >
-  {% if page.extra.cover_image %}
+  {% if page.extra.cover.image %}
   <figure class="mb-4 mt-0">
     <img
       class="h-auto w-full rounded-lg"
-      src="{{ get_url(path=page.extra.cover_image) }}"
-      alt="cover"
+      src="{{ get_url(path=page.extra.cover.image) }}"
+      alt="{{ page.extra.cover.caption | default(value='cover') }}"
+      title="{{ page.extra.cover.caption | default(value='cover') }}"
     />
   </figure>
   {% endif %}<!---->

--- a/templates/partials/page_list.html
+++ b/templates/partials/page_list.html
@@ -17,8 +17,7 @@
     <img
       class="h-auto w-full rounded-lg"
       src="{{ get_url(path=page.extra.cover.image) }}"
-      alt="{{ page.extra.cover.caption | default(value='cover') }}"
-      title="{{ page.extra.cover.caption | default(value='cover') }}"
+      alt="{{ page.extra.cover.alt | default(value='cover') }}"
     />
   </figure>
   {% endif %}<!---->


### PR DESCRIPTION
Give the option to provide a caption for the cover image on a page.
If provided, this caption is also used as an alternate text, increasing the accessibility for any user with a screen reader.