### PR TITLE
Defer loading the KaTeX CSS

### DIFF
--- a/templates/partials/math.html
+++ b/templates/partials/math.html
@@ -1,4 +1,5 @@
 <link
+  defer
   rel="stylesheet"
   href="https://cdn.jsdelivr.net/npm/katex@0.16.7/dist/katex.min.css"
   integrity="sha384-3UiQGuEI4TTMaFmGIZumfRPtfKQ3trwQE2JgosJxCnGmQpL/lJdjpcHkaaFwHlcI"


### PR DESCRIPTION
In the `math.html` partial template, the loading of the KaTeX js is deferred, but not the CSS.
This means that nothing is rendered until the KaTeX CSS is loaded, which may take a lot more time than fetching the page content.

This PR adds `defer` to the KaTeX CSS loading. This makes the website more responsive on slower connections (at the cost of showing the math content un-rendered, and updating the page once everything is loaded).

There might be edge cases where the js is loaded *before* the CSS is loaded, and math will be converted but not shown, but I think this is an acceptable cost for making the content show up much faster on slower connections.